### PR TITLE
embed DLL at compile time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+stab.exe

--- a/README.md
+++ b/README.md
@@ -9,11 +9,16 @@ This project provides the `MemoryLoadLibrary(...)` function which can load a DLL
 This project also contains a little main function as an example of how to use the methods. 
 
 ```
+#Build
 GOOS=windows go build
 
  #Inject into the local process
-./stab .\Path\to\dll
+./stab.exe .\Path\to\dll
 
  #Inject into a remote process
-./stab .\Path\to\dll 2910
+./stab.exe .\Path\to\dll 2910
+
+#Build with embedded DLL (put DLL in pkg/embed/preload)
+GOOS=windows go build -tags=embed
+./stab.exe <pid>
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module reflectivePEdll
+module stab
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -1,34 +1,47 @@
 package main
 
 import (
+	_ "embed"
 	"io/ioutil"
 	"log"
 	"os"
-	"reflectivePEdll/pkg/manualmap"
+	embedCheck "stab/pkg/embed"
+	"stab/pkg/manualmap"
 	"strconv"
 	"time"
 )
 
 func loadDll(path string, pid int) error {
 
-	PEBytes, err := ioutil.ReadFile(path)
-	if err != nil {
-		return err
-	}
+	var PEBytes []byte
+	var err error
 
+	if embedCheck.IsEmbedded == true {
+		PEBytes = embedCheck.EmbeddedBytes
+		log.Println("Using embedded payload. Poggers!")
+	} else {
+		PEBytes, err = ioutil.ReadFile(path)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
 	return manualmap.MemoryLoadLibrary(PEBytes, pid)
 }
 
 func main() {
-	if len(os.Args) < 2 {
+	if len(os.Args) < 2 && embedCheck.IsEmbedded == false {
 		log.Println("Give dll path")
 		return
 	}
 
 	pid := os.Getpid()
-	if len(os.Args) > 2 {
+	if len(os.Args) > 2 || (embedCheck.IsEmbedded == true && len(os.Args) > 1) {
 		var err error
-		pid, err = strconv.Atoi(os.Args[2])
+		if embedCheck.IsEmbedded == false {
+			pid, err = strconv.Atoi(os.Args[2])
+		} else {
+			pid, err = strconv.Atoi(os.Args[1])
+		}
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -36,7 +49,11 @@ func main() {
 
 	log.Println("Starting load...")
 
-	log.Println(loadDll(os.Args[1], pid))
+	if len(os.Args) > 1 {
+		loadDll(os.Args[1], pid)
+	} else {
+		loadDll("asdfghjkl", pid)
+	}
 
 	if pid == os.Getpid() {
 		time.Sleep(10 * time.Minute)

--- a/pkg/embed/noEmbeddedPayload.go
+++ b/pkg/embed/noEmbeddedPayload.go
@@ -1,0 +1,10 @@
+// +build !embed
+
+package embedCheck
+
+var EmbeddedBytes []byte
+var IsEmbedded bool
+
+func init() {
+	IsEmbedded = false
+}

--- a/pkg/embed/preload
+++ b/pkg/embed/preload
@@ -1,0 +1,1 @@
+change me to an EVIL dll!

--- a/pkg/embed/yesEmbeddedPayload.go
+++ b/pkg/embed/yesEmbeddedPayload.go
@@ -1,0 +1,13 @@
+// +build embed
+
+package embedCheck
+
+import _ "embed"
+
+//go:embed preload
+var EmbeddedBytes []byte
+var IsEmbedded bool
+
+func init() {
+	IsEmbedded = true
+}


### PR DESCRIPTION
lets you embed a DLL at compile time. 
probably garbage, it's the first go i've written.

put a dll in pkg/embed/preload and `GOOS=windows go build -tags=embed`